### PR TITLE
Add `wide.css` and `wide.js` includes across site HTML pages

### DIFF
--- a/360Docs.html
+++ b/360Docs.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -786,6 +787,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/360Music.html
+++ b/360Music.html
@@ -18,6 +18,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -824,6 +825,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jsmediatags@3.9.7/dist/jsmediatags.min.js"></script>

--- a/360Notes.html
+++ b/360Notes.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -582,6 +583,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/360vids.html
+++ b/360vids.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -636,6 +637,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/404.html
+++ b/404.html
@@ -6,6 +6,7 @@
   <title>360 — Page Not Found</title>
   <link rel="icon" type="image/png" href="/favicon-32x32.png" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <style>
     body {
@@ -81,6 +82,7 @@
   </div>
 
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cursor.js"></script>
 </body>
 </html>

--- a/accounts.html
+++ b/accounts.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" href="favicon-32x32.png" />
   <link rel="apple-touch-icon" href="apple-touch-icon.png" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 
@@ -383,6 +384,7 @@
 
   <script>window.SKIP_AUTH_CHIP = true;</script>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/ai.html
+++ b/ai.html
@@ -9,6 +9,7 @@
   <meta name="theme-color" content="#3b82f6" />
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -443,6 +444,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <script src="/assets/js/ai.js"></script>

--- a/angelrng.html
+++ b/angelrng.html
@@ -8,6 +8,7 @@
 <link rel="manifest" href="../manifest.json" />
 <meta name="theme-color" content="#3b82f6" />
 <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
 <link rel="stylesheet" href="/assets/css/responsive.css" />
 <link rel="stylesheet" href="/assets/css/cursor.css" />
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -1383,6 +1384,7 @@ historyArray.forEach(entry => {
 </script>
 <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
 <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
 <script src="/assets/js/cookie.js"></script>
 <script src="/assets/js/cursor.js"></script>
 </body>

--- a/apps.html
+++ b/apps.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -321,6 +322,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 </body>

--- a/chat.html
+++ b/chat.html
@@ -21,6 +21,7 @@
   <link rel="icon" type="image/png" href="../favicon-32x32.png" />
   <link rel="manifest" href="../manifest.json" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -277,6 +278,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <script src="/assets/js/chat.js"></script>

--- a/games.html
+++ b/games.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="../manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -166,6 +167,7 @@
     
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/games/angelrng.html
+++ b/games/angelrng.html
@@ -8,6 +8,7 @@
 <link rel="manifest" href="/manifest.json" />
 <meta name="theme-color" content="#3b82f6" />
 <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
 <link rel="stylesheet" href="/assets/css/responsive.css" />
 <link rel="stylesheet" href="/assets/css/cursor.css" />
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -1379,6 +1380,7 @@ historyArray.forEach(entry => {
 </script>
 <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
 <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
 <script src="/assets/js/cookie.js"></script>
 <script src="/assets/js/cursor.js"></script>
 </body>

--- a/games/minesweeper.html
+++ b/games/minesweeper.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="../manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -1050,6 +1051,7 @@ ${JSON.stringify(exportState())}`
   </script>
 
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/games/spaceGlider.html
+++ b/games/spaceGlider.html
@@ -7,6 +7,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -910,6 +911,7 @@
   </script>
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 
   <!-- CSS -->
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/home.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
@@ -333,6 +334,7 @@
   </div>
 
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/home.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>

--- a/news.html
+++ b/news.html
@@ -15,6 +15,7 @@
   <link rel="manifest" href="../manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -502,6 +503,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/search-beta-beta.html
+++ b/search-beta-beta.html
@@ -26,6 +26,7 @@
 
   <!-- 360 OS CSS -->
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <link rel="stylesheet" href="/assets/css/search.css" />
@@ -223,6 +224,7 @@
 
   <!-- 360 OS Scripts -->
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/home.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>

--- a/search-beta.html
+++ b/search-beta.html
@@ -19,6 +19,7 @@
   <link rel="manifest" href="manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -892,6 +893,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <!-- Load GCSE silently -->

--- a/search.html
+++ b/search.html
@@ -19,6 +19,7 @@
   <link rel="manifest" href="manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -863,6 +864,7 @@
 
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <!-- Load GCSE silently -->

--- a/settings.html
+++ b/settings.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" href="favicon-32x32.png" />
   <link rel="apple-touch-icon" href="apple-touch-icon.png" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 
@@ -708,6 +709,7 @@
 
   <script>window.SKIP_AUTH_CHIP = true;</script>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/stocks.html
+++ b/stocks.html
@@ -15,6 +15,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -611,6 +612,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/translator.html
+++ b/translator.html
@@ -17,6 +17,7 @@
   <link rel="manifest" href="../manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -314,6 +315,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <script type="module">

--- a/url-shortener.html
+++ b/url-shortener.html
@@ -17,6 +17,7 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -118,6 +119,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
   <script>

--- a/weather.html
+++ b/weather.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/wide.css" />
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -644,6 +645,7 @@
 
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
+  <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 


### PR DESCRIPTION
### Motivation
- Add the drop-in wide stylesheet and script so the site can enable the wide layout/styles and corresponding JS behavior across pages.
- Ensure the new includes are placed immediately after the existing `main.css` and `main.js` references so load order and existing hooks remain unchanged.

### Description
- Inserted the `link` include `"/assets/css/wide.css"` immediately after existing `/assets/css/main.css` on HTML pages that use `main.css`, updating 24 files in total including `index.html`, `search.html`, `settings.html`, and pages under `games/`.
- Inserted the `script` include `"/assets/js/wide.js"` immediately after existing `/assets/js/main.js` in the same set of files.
- Changes are limited to HTML include lines and do not alter page logic beyond adding the new CSS/JS drop-in assets.

### Testing
- Ran the patching script that applied the replacements and reported the list of changed files, which updated 24 HTML files as expected and produced the file list output.
- Ran a verification check that scanned all HTML files for any occurrence of `/assets/css/main.css` or `/assets/js/main.js` missing the corresponding `/assets/css/wide.css` or `/assets/js/wide.js`, and the check returned `missing_count=0` indicating full coverage.
- Spot-checked occurrences with `rg` to confirm `wide.css` and `wide.js` now appear in representative pages (`index.html`, `search.html`, `settings.html`, `games/minesweeper.html`) and found the new includes present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbb80c98c832585d5a5c4dab1d4bf)