### PR TITLE
Restore sidebar nav animations and staggered app entry

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -99,6 +99,14 @@ body.dark .sidebar { background: rgba(9,9,11,.97); }
   transition: .2s;
   font-size: 14px;
   color: var(--txt);
+  opacity: 0;
+  transform: translateX(-16px);
+  transition:
+    background .2s,
+    color .2s,
+    opacity .28s ease,
+    transform .32s cubic-bezier(.22,.68,0,1.01);
+  transition-delay: 0s;
 }
 body.dark .nav-item { color: var(--txtd); }
 .nav-item:hover { background: rgba(148,163,184,.15); }
@@ -106,6 +114,12 @@ body.dark .nav-item { color: var(--txtd); }
   background: linear-gradient(120deg, var(--a), var(--a2));
   color: #050816;
   font-weight: 700;
+}
+
+.sidebar.open .nav-item {
+  opacity: 1;
+  transform: translateX(0);
+  transition-delay: calc(var(--nav-index, 0) * 0.2s);
 }
 
 .sidebar-footer {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -383,6 +383,11 @@ const settingsPanel = document.querySelector(".settings-panel");
 const overlay       = document.querySelector(".overlay");
 const sidebarToggle = document.querySelector(".sidebar-toggle");
 const settingsBtn   = document.getElementById("settingsBtn");
+const navItems      = Array.from(document.querySelectorAll(".sidebar .nav-item"));
+
+navItems.forEach((item, idx) => {
+  item.style.setProperty("--nav-index", String(idx));
+});
 
 function updateOverlay() {
   const anyOpen = sidebar?.classList.contains("open") || settingsPanel?.classList.contains("open");


### PR DESCRIPTION
### Motivation
- Restore the in/out motion for left navigation items so the sidebar feels animated rather than instantaneous on open/close. 
- Make the apps (nav items) slide in one-by-one with a short stagger (~0.2s) so the list entrance is sequential and polished. 
- Ensure the stagger ordering is deterministic across pages by assigning an index to each nav item from the shared sidebar script. 

### Description
- Updated `assets/css/main.css` to give `.nav-item` an initial hidden state (`opacity: 0`, `transform: translateX(-16px)`) and transitions for opacity/transform. 
- Added `.sidebar.open .nav-item` rules that animate items into place and apply `transition-delay: calc(var(--nav-index, 0) * 0.2s)` to create the stagger effect. 
- Updated `assets/js/main.js` to collect `.sidebar .nav-item` elements and set a per-item CSS variable `--nav-index` so the stagger is consistent and deterministic. 
- Kept existing sidebar open/close and overlay behavior intact and did not change navigation click handling. 

### Testing
- Ran `node --check assets/js/main.js` which completed successfully. 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd586d14c832592fc1d7e105dc5cc)