### PR TITLE
Refine CSS transitions for sidebar, settings panel, and wide-mode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -67,7 +67,7 @@ body.dark {
   display: flex;
   flex-direction: column;
   transform: translateX(-100%);
-  transition: .3s;
+  transition: transform .3s ease;
   z-index: 60;
 }
 body.dark .sidebar { background: rgba(9,9,11,.97); }
@@ -165,7 +165,7 @@ body.dark .sidebar-footer { color: var(--mutd); }
   border-left: 1px solid var(--br);
   padding: 20px 16px;
   transform: translateX(100%);
-  transition: transform .3s;
+  transition: transform .3s ease;
   z-index: 65;
   overflow-y: auto;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -99,7 +99,7 @@ body.dark {
   display: flex;
   flex-direction: column;
   transform: translateX(-100%);
-  transition: .3s;
+  transition: transform .3s ease;
   z-index: 60;
 }
 
@@ -217,7 +217,7 @@ body.dark .sidebar-footer {
   border-left: 1px solid var(--br);
   padding: 16px;
   transform: translateX(100%);
-  transition: .3s;
+  transition: transform .3s ease;
   z-index: 65;
 }
 

--- a/assets/css/wide.css
+++ b/assets/css/wide.css
@@ -364,5 +364,6 @@ body .custom-search-form {
     background 0.35s ease,
     border-color 0.35s ease,
     box-shadow 0.35s ease,
-    backdrop-filter 0.35s ease !important;
+    backdrop-filter 0.35s ease,
+    transform 0.3s ease !important;
 }


### PR DESCRIPTION
### Motivation
- Improve animation smoothness and consistency for off-canvas UI elements by explicitly targeting `transform` and adding easing to transitions.

### Description
- Replace generic `transition: .3s;` with `transition: transform .3s ease;` for `.sidebar` and `.settings-panel` in `assets/css/main.css` and `assets/css/styles.css` to scope animations to movement only.
- Update `assets/css/wide.css` transition list to include `transform 0.3s ease !important` and make the `backdrop-filter` transition explicit so wide-mode cross-fades and transforms animate consistently.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b3fc8188325b65ea70807b19c7c)