### PR TITLE
Fix nav emoji visibility, back button history, and add ripple on nav click

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1341,3 +1341,39 @@ body.dark .nav-item {
 .vids-nav-item.active {
   -webkit-text-fill-color: initial !important;
 }
+
+
+/* Sidebar nav interactions */
+.nav-item {
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-ripple {
+  position: absolute;
+  border-radius: 50%;
+  transform: scale(0);
+  background: rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+  animation: navRipple 420ms ease-out;
+}
+
+body.dark .nav-ripple {
+  background: rgba(56, 189, 248, 0.35);
+}
+
+@keyframes navRipple {
+  to {
+    transform: scale(2.8);
+    opacity: 0;
+  }
+}
+
+/* Keep emoji glyphs visible regardless of theme text-fill tricks */
+.nav-item,
+.sidebar-toggle,
+#settingsBtn {
+  -webkit-text-fill-color: currentColor !important;
+  text-fill-color: currentColor;
+  font-variant-emoji: emoji;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -386,6 +386,49 @@ const sidebarToggle = document.querySelector(".sidebar-toggle");
 const settingsBtn   = document.getElementById("settingsBtn");
 const navItems      = Array.from(document.querySelectorAll(".sidebar .nav-item"));
 
+
+function trackPageVisit() {
+  const key = "navHistory";
+  const current = window.location.pathname || "/";
+  const raw = sessionStorage.getItem(key);
+  const history = raw ? JSON.parse(raw) : [];
+
+  if (!history.length || history[history.length - 1] !== current) {
+    history.push(current);
+  }
+
+  if (history.length > 30) history.splice(0, history.length - 30);
+  sessionStorage.setItem(key, JSON.stringify(history));
+}
+
+function goToLastVisitedPage() {
+  const key = "navHistory";
+  const current = window.location.pathname || "/";
+  const raw = sessionStorage.getItem(key);
+  const history = raw ? JSON.parse(raw) : [];
+
+  while (history.length && history[history.length - 1] === current) {
+    history.pop();
+  }
+
+  const target = history.pop();
+  sessionStorage.setItem(key, JSON.stringify(history));
+
+  if (target) {
+    window.location.href = target;
+    return;
+  }
+
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.href = "/";
+  }
+}
+
+trackPageVisit();
+
+
 /* Faster nav animation (reduce perceived lag) */
 navItems.forEach((item, idx) => {
   // Keep stagger but make it MUCH faster
@@ -443,11 +486,39 @@ navItems.forEach(item => {
   item.addEventListener("click", e => {
     e.stopPropagation();
 
+    const ripple = document.createElement("span");
+    ripple.className = "nav-ripple";
+    const rect = item.getBoundingClientRect();
+    const size = Math.max(rect.width, rect.height);
+    ripple.style.width = ripple.style.height = `${size}px`;
+    ripple.style.left = `${e.clientX - rect.left - size / 2}px`;
+    ripple.style.top = `${e.clientY - rect.top - size / 2}px`;
+    item.appendChild(ripple);
+    ripple.addEventListener("animationend", () => ripple.remove(), { once: true });
+
     const href = item.dataset.href;
-    if (href) window.location.href = href;
+    if (href) {
+      const current = window.location.pathname || "/";
+      const targetPath = new URL(href, window.location.origin).pathname;
+      if (targetPath !== current) {
+        const raw = sessionStorage.getItem("navHistory");
+        const history = raw ? JSON.parse(raw) : [];
+        if (!history.length || history[history.length - 1] !== current) history.push(current);
+        sessionStorage.setItem("navHistory", JSON.stringify(history.slice(-30)));
+      }
+      setTimeout(() => { window.location.href = href; }, 140);
+    }
 
     sidebar?.classList.remove("open");
     updateOverlay();
+  });
+});
+
+Array.from(document.querySelectorAll(".back-btn")).forEach(btn => {
+  btn.addEventListener("click", e => {
+    e.preventDefault();
+    e.stopPropagation();
+    goToLastVisitedPage();
   });
 });
 


### PR DESCRIPTION
### Motivation
- Theme text-fill/gradient rules were tinting or hiding emoji glyphs in the sidebar and related controls, making icons invisible.
- The back controls always returned to a fixed page instead of the actual last visited view, which is confusing when navigating within the app.
- Sidebar navigation had no tactile feedback, so clicks felt less responsive on touch/desktop devices.

### Description
- Added session-based navigation tracking with `trackPageVisit()` and a `goToLastVisitedPage()` fallback flow so back controls return to the most recently visited path before falling back to `history.back()` and `/` in `assets/js/main.js`.
- Reworked the sidebar nav click handler to append a positioned ripple element at the click point, delay navigation briefly so the ripple is visible, and record the previous path in session history in `assets/js/main.js`.
- Added CSS for the ripple animation and enforced non-gradient text-fill for nav/toggle/settings elements so emoji glyphs render correctly across themes in `assets/css/main.css`.
- Kept history size bounded (last 30 entries) and removed duplicates of the current path to prevent noisy back targets.

### Testing
- Verified the produced diff with `git diff -- assets/js/main.js assets/css/main.css` and inspected inserted code, which matched the intended changes (succeeded). 
- Added and committed the updated files with `git add` and `git commit -m "Fix nav emoji visibility, back behavior, and click ripple"`, which completed successfully. 
- No unit tests exist for this UI behavior in the repo, so verification was performed via the automated diffs and commits above (no failing automated tests encountered).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a7923f988325b72a880f21fd14a1)