### PR TITLE
Enhance theme swatch hover and style background image upload button

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -247,11 +247,30 @@
       cursor: pointer; font-size: 11px; color: var(--mut);
     }
     .st-swatch {
-      width: 36px; height: 36px; border-radius: 10px;
+      width: 36px; height: 36px; border-radius: 50%;
       border: 2.5px solid transparent;
-      transition: transform .15s, border-color .15s;
+      transition: transform .18s ease, border-color .15s, box-shadow .18s ease;
     }
-    .st-swatch:hover { transform: scale(1.1); }
+    .st-swatch:hover {
+      transform: scale(1.15);
+      box-shadow: 0 8px 18px rgba(0,0,0,.18);
+    }
+
+    .st-upload-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+      font-weight: 600;
+      border-color: rgba(59,130,246,.35);
+      background: linear-gradient(135deg, rgba(59,130,246,.16), rgba(139,92,246,.12));
+    }
+    .st-upload-btn::before { content: "🖼️"; font-size: 14px; }
+    .st-upload-btn:hover {
+      border-color: rgba(59,130,246,.6);
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(59,130,246,.18);
+    }
     .st-swatch.active { border-color: var(--a,#3b82f6); }
     .st-swatch[data-theme="ocean"]    { background: linear-gradient(135deg,#3b82f6,#8b5cf6); }
     .st-swatch[data-theme="midnight"] { background: linear-gradient(135deg,#1e293b,#334155); }
@@ -605,8 +624,8 @@
               <div class="st-row-label">Upload Image</div>
               <div class="st-row-sub">Set a custom background on the 360 home page.</div>
             </div>
-            <label class="st-btn" style="cursor:pointer;">
-              Choose File
+            <label class="st-btn st-upload-btn">
+              Choose Background Image
               <input type="file" id="visBgUpload" accept="image/*" style="display:none;" />
             </label>
           </div>


### PR DESCRIPTION
### Motivation
- Improve the visual affordance of theme color options so hovering gives clearer feedback that the swatch is interactive. 
- Make the background image chooser more prominent and descriptive to reduce confusion when uploading a custom background.

### Description
- Updated `.st-swatch` in `settings.html` to use `border-radius: 50%`, increased hover scale, longer easing, and added a subtle shadow for stronger hover feedback. 
- Extended transition properties on swatches to include `box-shadow` and adjusted timing to `transform .18s ease` for a smoother effect. 
- Added a new `.st-upload-btn` style variant with gradient background, icon pseudo-element, stronger border color, and hover lift/shadow. 
- Applied the new upload style and updated the label text from `Choose File` to `Choose Background Image` in `settings.html`.

### Testing
- No automated tests were run since this is a CSS/HTML-only UI tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2aa9307d483259690c5e1b6b7b608)