### PR TITLE
Add click ripple effect to cards and refine settings theme UI

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -77,6 +77,18 @@
     }
     .app-card:hover::before { opacity: 1; }
 
+    .app-card .card-ripple {
+      position: absolute;
+      border-radius: 50%;
+      transform: scale(0);
+      animation: card-ripple .55s ease-out;
+      background: rgba(255,255,255,.45);
+      pointer-events: none;
+    }
+    @keyframes card-ripple {
+      to { transform: scale(4); opacity: 0; }
+    }
+
     .app-icon { font-size: 38px; line-height: 1; }
     .app-title { font-size: 15px; font-weight: 700; color: var(--txt); }
     body.dark .app-title { color: var(--txtd); }
@@ -320,6 +332,30 @@
     </div>
   </div>
 
+
+  <script>
+    (function () {
+      const cards = document.querySelectorAll('.app-card');
+      cards.forEach((card) => {
+        card.addEventListener('click', (event) => {
+          const ripple = document.createElement('span');
+          ripple.className = 'card-ripple';
+
+          const rect = card.getBoundingClientRect();
+          const size = Math.max(rect.width, rect.height);
+          ripple.style.width = ripple.style.height = `${size}px`;
+          ripple.style.left = `${event.clientX - rect.left - size / 2}px`;
+          ripple.style.top = `${event.clientY - rect.top - size / 2}px`;
+
+          const oldRipple = card.querySelector('.card-ripple');
+          if (oldRipple) oldRipple.remove();
+
+          card.appendChild(ripple);
+          ripple.addEventListener('animationend', () => ripple.remove(), { once: true });
+        });
+      });
+    })();
+  </script>
   <audio id="clickSound" src="click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
   <script src="/assets/js/wide.js"></script>

--- a/games.html
+++ b/games.html
@@ -12,6 +12,26 @@
   <link rel="stylesheet" href="/assets/css/responsive.css" />
   <link rel="stylesheet" href="/assets/css/cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <style>
+    .game-card {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+    }
+    .game-card .card-ripple {
+      position: absolute;
+      border-radius: 50%;
+      transform: scale(0);
+      animation: card-ripple .55s ease-out;
+      background: rgba(255,255,255,.45);
+      pointer-events: none;
+      z-index: 1;
+    }
+    @keyframes card-ripple {
+      to { transform: scale(4); opacity: 0; }
+    }
+  </style>
 </head>
 <body>
 
@@ -165,6 +185,30 @@
   </div>
 </div>
     
+
+  <script>
+    (function () {
+      const cards = document.querySelectorAll('.game-card');
+      cards.forEach((card) => {
+        card.addEventListener('click', (event) => {
+          const ripple = document.createElement('span');
+          ripple.className = 'card-ripple';
+
+          const rect = card.getBoundingClientRect();
+          const size = Math.max(rect.width, rect.height);
+          ripple.style.width = ripple.style.height = `${size}px`;
+          ripple.style.left = `${event.clientX - rect.left - size / 2}px`;
+          ripple.style.top = `${event.clientY - rect.top - size / 2}px`;
+
+          const oldRipple = card.querySelector('.card-ripple');
+          if (oldRipple) oldRipple.remove();
+
+          card.appendChild(ripple);
+          ripple.addEventListener('animationend', () => ripple.remove(), { once: true });
+        });
+      });
+    })();
+  </script>
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="/assets/js/main.js"></script>
   <script src="/assets/js/wide.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -247,11 +247,30 @@
       cursor: pointer; font-size: 11px; color: var(--mut);
     }
     .st-swatch {
-      width: 36px; height: 36px; border-radius: 10px;
+      width: 36px; height: 36px; border-radius: 50%;
       border: 2.5px solid transparent;
-      transition: transform .15s, border-color .15s;
+      transition: transform .18s ease, border-color .15s, box-shadow .18s ease;
     }
-    .st-swatch:hover { transform: scale(1.1); }
+    .st-swatch:hover {
+      transform: scale(1.15);
+      box-shadow: 0 8px 18px rgba(0,0,0,.18);
+    }
+
+    .st-upload-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+      font-weight: 600;
+      border-color: rgba(59,130,246,.35);
+      background: linear-gradient(135deg, rgba(59,130,246,.16), rgba(139,92,246,.12));
+    }
+    .st-upload-btn::before { content: "🖼️"; font-size: 14px; }
+    .st-upload-btn:hover {
+      border-color: rgba(59,130,246,.6);
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(59,130,246,.18);
+    }
     .st-swatch.active { border-color: var(--a,#3b82f6); }
     .st-swatch[data-theme="ocean"]    { background: linear-gradient(135deg,#3b82f6,#8b5cf6); }
     .st-swatch[data-theme="midnight"] { background: linear-gradient(135deg,#1e293b,#334155); }
@@ -605,8 +624,8 @@
               <div class="st-row-label">Upload Image</div>
               <div class="st-row-sub">Set a custom background on the 360 home page.</div>
             </div>
-            <label class="st-btn" style="cursor:pointer;">
-              Choose File
+            <label class="st-btn st-upload-btn">
+              Choose Background Image
               <input type="file" id="visBgUpload" accept="image/*" style="display:none;" />
             </label>
           </div>


### PR DESCRIPTION
### Motivation
- Add visual click feedback for app and game cards to improve perceived responsiveness and polish the UI.
- Make theme swatches feel more tactile and provide a clearer background image upload affordance in settings.

### Description
- Implement a CSS/JS ripple effect by adding `.card-ripple` styles, a `@keyframes card-ripple` animation, and a small inline script to `apps.html` that creates and cleans up the ripple on card `click` events.
- Add the same ripple stylesheet and script to `games.html`, scoped to `.game-card`, and set `z-index` to ensure the ripple appears above card content.
- Update `settings.html` UI: change `.st-swatch` border-radius to `50%`, refine transitions, add hover scale and shadow, introduce a new `.st-upload-btn` style with an emoji pseudo-element and hover state, and update the background upload label text to `Choose Background Image` while wiring the hidden `input[type=file]` unchanged.

### Testing
- No automated tests were added or run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2aa9307d483259690c5e1b6b7b608)