### PR TITLE
Fix OrbitOS asset paths in OS/orbitos.html

### DIFF
--- a/OS/orbitos.html
+++ b/OS/orbitos.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>OrbitOS — 360 Digital</title>
-<link rel="stylesheet" href="OS/style.css">
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 
@@ -267,6 +267,6 @@ Start typing your notes here...</textarea>
   <div id="notif-stack"></div>
 </div>
 
-<script src="OS/app.js"></script>
+<script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The HTML file referenced its CSS and JS with an extra `OS/` prefix which caused incorrect resolutions (e.g. `OS/OS/style.css`) when `orbitos.html` is already located in `OS/`, breaking asset loading.

### Description
- Updated `OS/orbitos.html` to remove the redundant directory prefix by changing the stylesheet link from `OS/style.css` to `style.css` and the script source from `OS/app.js` to `app.js` in the same file.

### Testing
- Verified the changes by inspecting `OS/orbitos.html` with `nl -ba OS/orbitos.html | sed -n '1,30p;280,340p'` and `nl -ba OS/orbitos.html | tail -n 25`, and confirmed the updated `href` and `src` entries appeared as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3c6710f4832692ed238658760dd6)