### PR TITLE
Add draggable customizable homepage widgets with settings UI

### DIFF
--- a/assets/js/widgets.js
+++ b/assets/js/widgets.js
@@ -1,0 +1,149 @@
+(function () {
+  const STORAGE_KEY = '360_widgets_v1';
+  const TYPES = {
+    weather: { label: 'Weather' },
+    time: { label: 'Time' },
+    note: { label: 'Note' }
+  };
+
+  function loadWidgets() {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); } catch { return []; }
+  }
+  function saveWidgets(w) { localStorage.setItem(STORAGE_KEY, JSON.stringify(w)); }
+  function uid() { return `w_${Date.now()}_${Math.random().toString(36).slice(2,8)}`; }
+
+  async function getWeather(lat, lon, unit) {
+    const tempUnit = unit === 'F' ? 'fahrenheit' : 'celsius';
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m&temperature_unit=${tempUnit}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    return data?.current?.temperature_2m;
+  }
+
+  function startIndexMode() {
+    const host = document.getElementById('widgetBoard');
+    if (!host) return;
+    let widgets = loadWidgets();
+
+    function render() {
+      host.innerHTML = '';
+      widgets.forEach(w => {
+        const card = document.createElement('section');
+        card.className = 'home-widget';
+        card.dataset.id = w.id;
+        card.style.left = (w.x || 20) + 'px';
+        card.style.top = (w.y || 20) + 'px';
+        card.style.width = (w.width || 220) + 'px';
+        card.style.height = (w.height || 130) + 'px';
+
+        const header = document.createElement('div');
+        header.className = 'home-widget-header';
+        header.textContent = w.title || TYPES[w.type]?.label || 'Widget';
+
+        const body = document.createElement('div');
+        body.className = 'home-widget-body';
+        card.append(header, body);
+        host.appendChild(card);
+
+        if (w.type === 'time') {
+          const locale = w.locale || undefined;
+          const tz = w.timezone || undefined;
+          const f = () => { body.textContent = new Date().toLocaleTimeString(locale, { timeZone: tz, hour: '2-digit', minute: '2-digit', second: '2-digit' }); };
+          f();
+          setInterval(f, 1000);
+        } else if (w.type === 'note') {
+          body.textContent = w.text || 'Empty note';
+        } else if (w.type === 'weather') {
+          body.textContent = 'Loading weather…';
+          const unit = w.unit || 'C';
+          const setFallback = () => body.textContent = 'Weather unavailable';
+          if (!navigator.geolocation) setFallback();
+          else navigator.geolocation.getCurrentPosition(async pos => {
+            try {
+              const t = await getWeather(pos.coords.latitude, pos.coords.longitude, unit);
+              body.textContent = t == null ? 'Weather unavailable' : `${Math.round(t)}°${unit}`;
+            } catch { setFallback(); }
+          }, setFallback);
+        }
+
+        makeDraggable(card, w);
+      });
+    }
+
+    function makeDraggable(el, widget) {
+      const header = el.querySelector('.home-widget-header');
+      let sx=0, sy=0, ox=0, oy=0, dragging=false;
+      header.addEventListener('pointerdown', e => {
+        dragging = true;
+        sx = e.clientX; sy = e.clientY;
+        ox = widget.x || 20; oy = widget.y || 20;
+        el.setPointerCapture(e.pointerId);
+      });
+      header.addEventListener('pointermove', e => {
+        if (!dragging) return;
+        widget.x = Math.max(0, ox + e.clientX - sx);
+        widget.y = Math.max(0, oy + e.clientY - sy);
+        el.style.left = widget.x + 'px';
+        el.style.top = widget.y + 'px';
+      });
+      header.addEventListener('pointerup', () => {
+        dragging = false;
+        saveWidgets(widgets);
+      });
+    }
+
+    render();
+  }
+
+  function startSettingsMode() {
+    const list = document.getElementById('widgetList');
+    if (!list) return;
+    const form = document.getElementById('widgetForm');
+    const type = document.getElementById('widgetType');
+    const title = document.getElementById('widgetTitle');
+    const width = document.getElementById('widgetWidth');
+    const height = document.getElementById('widgetHeight');
+    const noteText = document.getElementById('widgetText');
+    const unit = document.getElementById('widgetUnit');
+    const timezone = document.getElementById('widgetTimezone');
+    const locale = document.getElementById('widgetLocale');
+    let widgets = loadWidgets();
+
+    function refresh() {
+      list.innerHTML = widgets.map(w => `<div class="st-row"><div><div class="st-row-label">${w.title || w.type}</div><div class="st-row-sub">${w.type} • ${w.width}x${w.height}</div></div><div class="st-row-right"><button class="st-btn" data-act="del" data-id="${w.id}">Delete</button></div></div>`).join('') || '<div class="st-row-sub">No widgets yet.</div>';
+      saveWidgets(widgets);
+    }
+
+    list.addEventListener('click', e => {
+      const btn = e.target.closest('button[data-act="del"]');
+      if (!btn) return;
+      widgets = widgets.filter(w => w.id !== btn.dataset.id);
+      refresh();
+    });
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      widgets.push({
+        id: uid(),
+        type: type.value,
+        title: title.value.trim() || TYPES[type.value].label,
+        width: Number(width.value) || 220,
+        height: Number(height.value) || 130,
+        text: noteText.value.trim(),
+        unit: unit.value,
+        timezone: timezone.value.trim(),
+        locale: locale.value.trim(),
+        x: 20,
+        y: 20
+      });
+      form.reset();
+      refresh();
+    });
+    refresh();
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    startIndexMode();
+    startSettingsMode();
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -148,6 +148,11 @@
     }
     .bob-track.on { background: var(--a); }
     .bob-track.on::before { transform: translateX(16px); }
+    #widgetBoard { position: fixed; inset: 0; pointer-events: none; z-index: 5; }
+    .home-widget { position: absolute; pointer-events: auto; border:1px solid var(--br); background: rgba(15,23,42,.6); color: #fff; border-radius: 12px; overflow: hidden; backdrop-filter: blur(8px); }
+    .home-widget-header { padding: 8px 10px; font-size: 12px; font-weight: 700; cursor: grab; background: rgba(59,130,246,.35); user-select:none; }
+    .home-widget-body { padding: 10px; font-size: 18px; }
+
   </style>
 </head>
 <body>
@@ -270,6 +275,9 @@
       </div>
     </div>
 
+    <h3 style="margin-top:25px;">Advanced</h3>
+    <a href="settings.html?tab=preference" class="legal-link">🧩 Widget Settings</a>
+
     <h3 style="margin-top:25px;">Legal</h3>
     <a href="privacypolicy.html" class="legal-link">🔒 Privacy Policy</a>
     <a href="tos.html" class="legal-link">📜 Terms of Service</a>
@@ -301,6 +309,7 @@
   </div>
 
   <!-- HOME PAGE CONTENT -->
+  <div id="widgetBoard" aria-label="Homepage widget board"></div>
   <div class="home-inner">
     <br><br>
     <div class="clock-pill" id="clock">--:--</div>
@@ -336,6 +345,7 @@
   <script src="/assets/js/main.js"></script>
   <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/home.js"></script>
+  <script src="/assets/js/widgets.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
 

--- a/settings.html
+++ b/settings.html
@@ -654,6 +654,32 @@
           </div>
         </div>
 
+
+        <div class="st-card">
+          <div class="st-card-title">Widgets</div>
+          <form id="widgetForm" style="display:grid;gap:8px;">
+            <select id="widgetType" class="st-input">
+              <option value="weather">Weather widget</option>
+              <option value="time">Time widget</option>
+              <option value="note">Note widget</option>
+            </select>
+            <input id="widgetTitle" class="st-input" placeholder="Widget title" />
+            <div style="display:flex;gap:8px;">
+              <input id="widgetWidth" class="st-input" type="number" min="140" value="220" placeholder="Width" />
+              <input id="widgetHeight" class="st-input" type="number" min="80" value="130" placeholder="Height" />
+            </div>
+            <input id="widgetText" class="st-input" placeholder="Note text (for note widget)" />
+            <div style="display:flex;gap:8px;">
+              <select id="widgetUnit" class="st-input"><option value="C">Celsius</option><option value="F">Fahrenheit</option></select>
+              <input id="widgetTimezone" class="st-input" placeholder="Timezone (optional, e.g. America/New_York)" />
+            </div>
+            <input id="widgetLocale" class="st-input" placeholder="Locale (optional, e.g. en-US)" />
+            <button class="st-btn primary" type="submit">Add Widget</button>
+          </form>
+          <div id="widgetList" style="margin-top:12px;"></div>
+          <div class="st-row-sub" style="margin-top:10px;">Tip: drag widgets around on the homepage after adding them.</div>
+        </div>
+
         <!-- About -->
         <div class="st-card">
           <div class="st-card-title">About 360</div>
@@ -731,6 +757,7 @@
   <script src="/assets/js/wide.js"></script>
   <script src="/assets/js/cookie.js"></script>
   <script src="/assets/js/cursor.js"></script>
+  <script src="/assets/js/widgets.js"></script>
 
   <script>
   // ────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide a simple, user-configurable widgets system so users can add weather, time, and note widgets to the homepage and position them freely. 
- Make widget creation and management available in the existing Settings UI so configuration is discoverable and persistent.

### Description
- Added a new client script `assets/js/widgets.js` that persists widget definitions to `localStorage` under the key `360_widgets_v1`, renders widgets on the homepage, and supports Weather, Time, and Note widget types. 
- Wire `widgets.js` into both `index.html` and `settings.html` so widgets render on the home board and the Settings page can create/delete widgets. 
- Added a homepage widget container `#widgetBoard` and related CSS rules to `index.html` to host draggable widgets and provide basic styling. 
- Added a Widgets card to the Preferences panel in `settings.html` containing the `#widgetForm` for creating widgets and `#widgetList` for listing/deleting them; the form supports title, size, unit, timezone, locale, and note text fields.
- Weather widgets use browser geolocation + Open-Meteo API and Time widgets optionally support timezone/locale; widgets are draggable via pointer events and positions are saved back to localStorage.

### Testing
- Performed a static syntax check on the new script with `node --check assets/js/widgets.js`, which passed. 
- Manual smoke flows exercised in-browser rendering and persistence: adding widgets in `settings.html`, confirming they appear on `index.html`, dragging to new positions, and verifying positions persist across reloads (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1cfd44ac83258f25f0aadfe756d6)