### PR TITLE
Add 360 Gallium toggle to settings and ensure pages load Gallium assets

### DIFF
--- a/assets/js/gallium.js
+++ b/assets/js/gallium.js
@@ -207,8 +207,19 @@
     const prefPanel = document.getElementById("panel-preference");
     if (!prefPanel) return;
 
+    const existingToggle = document.getElementById("settingsGalliumToggle");
+    if (existingToggle) {
+      existingToggle.classList.toggle("on", galliumOn);
+      existingToggle.addEventListener("click", function() {
+        toggle();
+        this.classList.toggle("on", galliumOn);
+      });
+      return;
+    }
+
     const card = document.createElement("div");
     card.className = "st-card";
+    card.id = "settingsGalliumCard";
     card.innerHTML = `
       <div class="st-card-title">360 Gallium</div>
       <div style="display:flex;align-items:center;justify-content:space-between;gap:14px;">

--- a/settings.html
+++ b/settings.html
@@ -636,6 +636,20 @@
           </div>
         </div>
 
+        <!-- 360 Gallium -->
+        <div class="st-card" id="settingsGalliumCard">
+          <div class="st-card-title">360 Gallium</div>
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:14px;">
+            <div>
+              <div style="font-size:14px;font-weight:500;">Enable 360 Gallium</div>
+              <div style="font-size:12px;color:var(--mut);margin-top:2px;">
+                Deep Liquid Glass — refractive and cursor-lit. Replaces 360 Wide when on.
+              </div>
+            </div>
+            <button class="st-toggle" id="settingsGalliumToggle"></button>
+          </div>
+        </div>
+
         <!-- About -->
         <div class="st-card">
           <div class="st-card-title">About 360</div>

--- a/spaceGlider.html
+++ b/spaceGlider.html
@@ -8,6 +8,7 @@
   <meta name="theme-color" content="#3b82f6" />
   <link rel="stylesheet" href="../main.css" />
   <link rel="stylesheet" href="../responsive.css" />
+  <link rel="stylesheet" href="/assets/css/gallium.css" />
   <link rel="stylesheet" href="../cursor.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <style>
@@ -901,6 +902,7 @@
   <audio id="clickSound" src="../click-sound.mp3" preload="auto"></audio>
   <script src="../main.js"></script>
   <script src="/assets/js/auth-fix.js"></script>
+  <script src="/assets/js/gallium.js"></script>
   <script src="../cookie.js"></script>
   <script src="../cursor.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Ensure the 360 Gallium UI mode is available from pages that include the nav/sidebar and from the settings panel so users can toggle the feature site-wide.
- Prevent duplicate toggle injection when a visible toggle is already present in `settings.html`.
- Make the Gallium toggle available on a remaining game page that used the site sidebar (`spaceGlider.html`).

### Description
- Added the Gallium stylesheet and script includes to `spaceGlider.html` by adding `"/assets/css/gallium.css"` and `"/assets/js/gallium.js"` so the sidebar/settings bar can inject and control Gallium there.
- Inserted a visible 360 Gallium card into `settings.html` under the Preferences panel with a toggle button using the id `settingsGalliumToggle` so users can toggle Gallium from the settings UI.
- Updated `assets/js/gallium.js` to detect an existing `settingsGalliumToggle` and wire its click/state instead of always injecting a duplicate card, and assigned an id `settingsGalliumCard` to the injected card for idempotence.

### Testing
- Ran a verification script that confirmed every HTML file containing a sidebar/settings scaffold includes `"/assets/css/gallium.css"` and `"/assets/js/gallium.js"`, and it reported no missing pages (passed).
- Ran `node --check assets/js/gallium.js` to validate the modified JS (passed).
- Ran `git diff --check` to ensure no whitespace/patch issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4abf9c50e0832dafbf9afb77c0360f)